### PR TITLE
Correct the vim.org link to the plugin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ support:
 
 Like db.vim?  Star the repository on
 [GitHub](https://tpope.io/vim/db) and vote for it on
-[vim.org](https://www.vim.org/scripts/script.php?script_id=0).
+[vim.org](https://www.vim.org/scripts/script.php?script_id=5665).
 
 Love db.vim?  Follow [tpope](http://tpo.pe/) on
 [GitHub](https://github.com/tpope) and


### PR DESCRIPTION
Update the `README` with the correct link to this plugin on `vim.org`.